### PR TITLE
Added read for hosts.{allow,deny} for pulse

### DIFF
--- a/profiles/usr.bin.pulseaudio
+++ b/profiles/usr.bin.pulseaudio
@@ -64,4 +64,7 @@
     /etc/core/sys/asound.conf r,
     /etc/core/sys/secure/pulse.cookie rk,
 
+    /etc/hosts.allow r,
+    /etc/hosts.deny r,
+
 }


### PR DESCRIPTION
Pulse was unable to read its own ACLs in hosts.allow and hosts.deny